### PR TITLE
Add an example of iframe not working

### DIFF
--- a/cross-document-iframe-parent.html
+++ b/cross-document-iframe-parent.html
@@ -49,7 +49,28 @@
       document.getElementById('generate-button').style.display = 'inline-block';
     }
 
+    /*********************************************************************/
+    /* Below contains custom element creating shadow element with iframe */
+    /*********************************************************************/
 
+    const childIframeSrc = "https://cobrowseio.github.io/cobrowse-sdk-js-examples/cross-document-iframe-child.html";
+
+    // Define the custom element
+    class shadowCustomElement extends HTMLElement {
+      constructor() {
+        super();
+
+        // Create the shadow DOM
+        const shadow = this.attachShadow({ mode: 'open' });
+        const content_area = document.createElement('div');
+        content_area.innerHTML = `<iframe src="${childIframeSrc}" height="400px" width="100%"></iframe>`;
+
+        shadow.appendChild(content_area);
+      }
+    }
+
+    // Register the custom element with the browser
+    customElements.define('shadow-custom-element', shadowCustomElement);
   </script>
   <style>
     body {
@@ -83,6 +104,11 @@
       -ms-user-select: none;
       user-select: none;
     }
+
+    #iframe-containers {
+      display: flex;
+      justify-content: space-evenly;
+    }
   </style>
 </head>
 
@@ -94,11 +120,12 @@
       <div id="support-code"></div>
     <button id="generate-button" onclick="generateSupportCode();">Generate Support Code</button>  
       <div style="height: 40px;"></div>
-    <div>
+
+    <div id="iframe-containers">
       <iframe src="https://cobrowseio.github.io/cobrowse-sdk-js-examples/cross-document-iframe-child.html" height="400px" width="30%"></iframe>
+      <shadow-custom-element style="width:30%" ></shadow-custom-element>
     </div>
-    </div>
-  
+
 </body>
 
 </html>


### PR DESCRIPTION
We found an edge case that iframe is not working. The PR reproduce the case when iframe is not working with current example code base.

In short, iframe is not visible when the iframe is used under custom element using shadow dom.

The PR creates a custom element called `<shadow-custom-element>` that creates a shadow dom with iframe that points out the same child iframe used.

Here are screenshots
Customer Client
<img width="1258" alt="Screen Shot 2023-04-03 at 6 13 57 PM" src="https://user-images.githubusercontent.com/4452675/229646562-ef749967-5a99-4e54-80aa-062c2f52b189.png">

Agent Client
<img width="1249" alt="Screen Shot 2023-04-03 at 6 13 44 PM" src="https://user-images.githubusercontent.com/4452675/229646580-3995bdfd-e27f-4b26-b1b3-7be1ab862e7b.png">


