### PR TITLE
Set default language if navigator.language is null

### DIFF
--- a/web-example/src/utils/formatAmount.js
+++ b/web-example/src/utils/formatAmount.js
@@ -1,8 +1,11 @@
 import LocaleCurrency from 'locale-currency'
 
 export const formatAmount = (amount) => {
-  return amount.toLocaleString(navigator.language, {
+  // If for some reason the language is not available, default to en-US
+  const language = navigator.language ?? 'en-US'
+
+  return amount.toLocaleString(language, {
     style: 'currency',
-    currency: LocaleCurrency.getCurrency(navigator.language)
+    currency: LocaleCurrency.getCurrency(language)
   })
 }


### PR DESCRIPTION
I haven't been able to reproduce this but adding this check should prevent an error if `navigator.language` happens to be empty for some reason.