### PR TITLE
feat: add device_registration_enabled  and session_code query params

### DIFF
--- a/web-example/src/App.jsx
+++ b/web-example/src/App.jsx
@@ -93,7 +93,9 @@ const App = () => {
       capabilities: getQueryParam('capabilities'),
       customData: getQueryParam('custom_data'),
       customSessionControls: getQueryParam('custom_session_controls'),
-      allowHeadless: getQueryParam('allow_headless')
+      allowHeadless: getQueryParam('allow_headless'),
+      sessionCode: getQueryParam('session_code'),
+      deviceRegistrationEnabled: getQueryParam('device_registration_enabled')
     })
   }, [start])
 

--- a/web-example/src/App.jsx
+++ b/web-example/src/App.jsx
@@ -95,7 +95,7 @@ const App = () => {
       customSessionControls: getQueryParam('custom_session_controls'),
       allowHeadless: getQueryParam('allow_headless'),
       sessionCode: getQueryParam('session_code'),
-      deviceRegistrationEnabled: getQueryParam('device_registration_enabled')
+      registration: getQueryParam('registration')
     })
   }, [start])
 

--- a/web-example/src/hooks/useCobrowse.js
+++ b/web-example/src/hooks/useCobrowse.js
@@ -39,7 +39,7 @@ export const useCobrowse = () => {
     }
   }, [CobrowseIO])
 
-  const start = useCallback(({ api, license, redactedViews, customData, capabilities, allowHeadless = false, customSessionControls = false } = {}) => {
+  const start = useCallback(({ api, license, redactedViews, customData, capabilities, sessionCode, allowHeadless = false, customSessionControls = false, deviceRegistrationEnabled = true } = {}) => {
     if (!CobrowseIO || cobrowseStarted.current) {
       return
     }
@@ -55,6 +55,7 @@ export const useCobrowse = () => {
     CobrowseIO.license = license || 'trial'
     CobrowseIO.redactedViews = redactedViews || ['.redacted', '#title', '#amount', '#subtitle', '#map']
     CobrowseIO.customData = customData || {}
+    CobrowseIO.registration = deviceRegistrationEnabled
 
     if (customSessionControls) {
       CobrowseIO.showSessionControls = () => true
@@ -81,8 +82,11 @@ export const useCobrowse = () => {
       }
     }
 
-    CobrowseIO.start({ allowIFrameStart: true, allowHeadless })
-
+    CobrowseIO.start({ allowIFrameStart: true, allowHeadless }).then(() => {
+      if (sessionCode) {
+        CobrowseIO.getSession(sessionCode)
+      }
+    })
     cobrowseStarted.current = true
   }, [CobrowseIO])
 

--- a/web-example/src/hooks/useCobrowse.js
+++ b/web-example/src/hooks/useCobrowse.js
@@ -39,7 +39,7 @@ export const useCobrowse = () => {
     }
   }, [CobrowseIO])
 
-  const start = useCallback(({ api, license, redactedViews, customData, capabilities, sessionCode, allowHeadless = false, customSessionControls = false, deviceRegistrationEnabled = true } = {}) => {
+  const start = useCallback(({ api, license, redactedViews, customData, capabilities, sessionCode, allowHeadless = false, customSessionControls = false, registration = true } = {}) => {
     if (!CobrowseIO || cobrowseStarted.current) {
       return
     }
@@ -55,7 +55,7 @@ export const useCobrowse = () => {
     CobrowseIO.license = license || 'trial'
     CobrowseIO.redactedViews = redactedViews || ['.redacted', '#title', '#amount', '#subtitle', '#map']
     CobrowseIO.customData = customData || {}
-    CobrowseIO.registration = deviceRegistrationEnabled
+    CobrowseIO.registration = registration
 
     if (customSessionControls) {
       CobrowseIO.showSessionControls = () => true


### PR DESCRIPTION
  I left the `session_code` query parameter which I'm not using atm but might be useful in the future.