### PR TITLE
feat: support sdk_path query param

### DIFF
--- a/web-example/README.md
+++ b/web-example/README.md
@@ -9,7 +9,7 @@
 
 ## Query Parameters
 
-The web demo can be used with `api`, `license`, `registration` and `custom_data parameters`. For security reasons do not allow for the `license` key or `api` to be set via a query parameter in your own application.
+The web demo can be used with `api`, `license`, `registration`, `sdk_path` and `custom_data parameters`. For security reasons **do not allow** for the `license` key, `sdk_path` or `api` to be set via a query parameter in your own application.
 
 Different integrations are also supported out of the box with the `integration` parameter: salesforce, zendesk, genesys, freshdesk, talkdesk.
 

--- a/web-example/public/index.html
+++ b/web-example/public/index.html
@@ -50,8 +50,11 @@
     </style>
     <title>Cobrowse demo</title>
     <script>
+      const params = new URLSearchParams(window.location.search);
+      const sdkPath = params.get('sdk_path') || 'https://js.cobrowse.io/CobrowseIO.js';
+
       (function(w,t,c,p,s,e){p=new Promise(function(r){w[c]={client:function(){if(!s){
-          s=document.createElement(t);s.src='https://js.cobrowse.io/CobrowseIO.js';s.async=1;
+          s=document.createElement(t);s.src=sdkPath;s.async=1;
           e=document.getElementsByTagName(t)[0];e.parentNode.insertBefore(s,e);s.onload=function()
           {r(w[c]);};}return p;}};});})(window,'script','CobrowseIO');
     </script>
@@ -61,7 +64,6 @@
     <div id="root"></div>
     <script>
       // Loading integrations here as some cause issues when loaded from the React app
-      const params = new URLSearchParams(window.location.search)
       const integration = params.get('integration')
 
       if (integration) {


### PR DESCRIPTION
@steprescott this is to support testing different versions of the SDK. I'm needing it at the moment to test a customer deployment which is not compatible with latest v3 SDK.