### PR TITLE
Allow ignored views to be passed

### DIFF
--- a/web-example/public/index.html
+++ b/web-example/public/index.html
@@ -284,6 +284,8 @@
               cobrowse_device_id: deviceId
             }
 
+            CobrowseIO.ignoredViews = ['.f9ChatWidget']
+
             F9.Chat.Wrapper.init({
               cdn: 'prod',
               useBusinessHours: false,

--- a/web-example/src/App.jsx
+++ b/web-example/src/App.jsx
@@ -98,6 +98,7 @@ const App = () => {
       license: getQueryParam('license'),
       redactedViews: getQueryParam('redacted_views'),
       unredactedViews: getQueryParam('unredacted_views'),
+      ignoredViews: getQueryParam('ignored_views'),
       capabilities: getQueryParam('capabilities'),
       customData: getQueryParam('custom_data'),
       customSessionControls: getQueryParam('custom_session_controls'),

--- a/web-example/src/hooks/useCobrowse.js
+++ b/web-example/src/hooks/useCobrowse.js
@@ -66,32 +66,20 @@ export const useCobrowse = () => {
 
     CobrowseIO.license = license ?? integrationLicense ?? 'trial'
     
-    CobrowseIO.redactedViews = [
-      ...(CobrowseIO.redactedViews || []),
-      ...(Array.isArray(redactedViews)
-      ? redactedViews
-      : (typeof redactedViews === 'string'
-      ? redactedViews.split(',').map(view => view.trim())
-      : ['.redacted', '#title', '#amount', '#subtitle', '#map']))
-    ]
+    const configureViews = (views, defaultViews) => {
+      return [
+      ...(views || []),
+      ...(Array.isArray(defaultViews)
+        ? defaultViews
+        : (typeof defaultViews === 'string'
+        ? defaultViews.split(',').map(view => view.trim())
+        : []))
+      ]
+    }
 
-    CobrowseIO.unredactedViews = [
-      ...(CobrowseIO.unredactedViews || []),
-      ...(Array.isArray(unredactedViews)
-      ? unredactedViews
-      : (typeof unredactedViews === 'string'
-      ? unredactedViews.split(',').map(view => view.trim())
-      : ['.unredacted']))
-    ]
-
-    CobrowseIO.ignoredViews = [
-      ...(CobrowseIO.ignoredViews || []),
-      ...(Array.isArray(ignoredViews)
-      ? ignoredViews
-      : (typeof ignoredViews === 'string'
-      ? ignoredViews.split(',').map(view => view.trim())
-      : []))
-    ]
+    CobrowseIO.redactedViews = configureViews(CobrowseIO.redactedViews, redactedViews || ['.redacted', '#title', '#amount', '#subtitle', '#map'])
+    CobrowseIO.unredactedViews = configureViews(CobrowseIO.unredactedViews, unredactedViews || ['.unredacted'])
+    CobrowseIO.ignoredViews = configureViews(CobrowseIO.ignoredViews, ignoredViews || [])
     
     CobrowseIO.customData = {
       device_name: 'Trial Website',

--- a/web-example/src/hooks/useCobrowse.js
+++ b/web-example/src/hooks/useCobrowse.js
@@ -47,7 +47,7 @@ export const useCobrowse = () => {
     }
   }, [CobrowseIO])
 
-  const start = useCallback(({ api, license, redactedViews, unredactedViews, customData, capabilities, sessionCode, allowHeadless = false, customSessionControls = false, registration = true, integration } = {}) => {
+  const start = useCallback(({ api, license, redactedViews, unredactedViews, ignoredViews, customData, capabilities, sessionCode, allowHeadless = false, customSessionControls = false, registration = true, integration } = {}) => {
     if (!CobrowseIO || cobrowseStarted.current) {
       return
     }
@@ -65,18 +65,33 @@ export const useCobrowse = () => {
       : undefined
 
     CobrowseIO.license = license ?? integrationLicense ?? 'trial'
+    
+    CobrowseIO.redactedViews = [
+      ...(CobrowseIO.redactedViews || []),
+      ...(Array.isArray(redactedViews)
+      ? redactedViews
+      : (typeof redactedViews === 'string'
+      ? redactedViews.split(',').map(view => view.trim())
+      : ['.redacted', '#title', '#amount', '#subtitle', '#map']))
+    ]
 
-    CobrowseIO.redactedViews = Array.isArray(redactedViews) 
-      ? redactedViews 
-      : (typeof redactedViews === 'string' 
-        ? redactedViews.split(',').map(view => view.trim()) 
-        : ['.redacted', '#title', '#amount', '#subtitle', '#map'])
+    CobrowseIO.unredactedViews = [
+      ...(CobrowseIO.unredactedViews || []),
+      ...(Array.isArray(unredactedViews)
+      ? unredactedViews
+      : (typeof unredactedViews === 'string'
+      ? unredactedViews.split(',').map(view => view.trim())
+      : ['.unredacted']))
+    ]
 
-    CobrowseIO.unredactedViews = Array.isArray(unredactedViews) 
-      ? unredactedViews 
-      : (typeof unredactedViews === 'string' 
-        ? unredactedViews.split(',').map(view => view.trim()) 
-        : ['.unredacted'])
+    CobrowseIO.ignoredViews = [
+      ...(CobrowseIO.ignoredViews || []),
+      ...(Array.isArray(ignoredViews)
+      ? ignoredViews
+      : (typeof ignoredViews === 'string'
+      ? ignoredViews.split(',').map(view => view.trim())
+      : []))
+    ]
     
     CobrowseIO.customData = {
       device_name: 'Trial Website',


### PR DESCRIPTION
- Adds `ignored_views` query parameter.
- Refactor redacted, unredacted and ignore views to merge with any values set via `CobrowseIO` object.