### PR TITLE
Simplify merging of selectors

### DIFF
--- a/web-example/src/hooks/useCobrowse.js
+++ b/web-example/src/hooks/useCobrowse.js
@@ -65,22 +65,18 @@ export const useCobrowse = () => {
       : undefined
 
     CobrowseIO.license = license ?? integrationLicense ?? 'trial'
-    
-    const configureViews = (views, defaultViews) => {
+
+    const mergeViews = (views, defaultViews) => {
       return [
-      ...(views || []),
-      ...(Array.isArray(defaultViews)
-        ? defaultViews
-        : (typeof defaultViews === 'string'
-        ? defaultViews.split(',').map(view => view.trim())
-        : []))
+        ...(views || []),
+        ...(defaultViews || [])
       ]
     }
 
-    CobrowseIO.redactedViews = configureViews(CobrowseIO.redactedViews, redactedViews || ['.redacted', '#title', '#amount', '#subtitle', '#map'])
-    CobrowseIO.unredactedViews = configureViews(CobrowseIO.unredactedViews, unredactedViews || ['.unredacted'])
-    CobrowseIO.ignoredViews = configureViews(CobrowseIO.ignoredViews, ignoredViews || [])
-    
+    CobrowseIO.redactedViews = mergeViews(CobrowseIO.redactedViews, redactedViews || ['.redacted', '#title', '#amount', '#subtitle', '#map'])
+    CobrowseIO.unredactedViews = mergeViews(CobrowseIO.unredactedViews, unredactedViews || ['.unredacted'])
+    CobrowseIO.ignoredViews = mergeViews(CobrowseIO.ignoredViews, ignoredViews || [])
+
     CobrowseIO.customData = {
       device_name: 'Trial Website',
       user_email: 'web@example.com',


### PR DESCRIPTION
As `getQueryValue` already checks for string we will always have an array.