### PR TITLE
fix(servicenow): always start chat without history on Yokohama

### DIFF
--- a/web-example/public/index.html
+++ b/web-example/public/index.html
@@ -380,7 +380,7 @@
             const chat = new ServiceNowChat({
               instance: snUrl,
               context: {
-                skip_load_history: 1,
+                skip_load_history: true,
                 cobrowse_device_id: deviceId
               },
             });


### PR DESCRIPTION
As of the Yokohama release, ServiceNow now requires `true` rather than `1` for truthy parameters.

This ensures the ServiceNow chat window always starts fresh. When recording demos it's not helpful to have the old chat history appear.