### PR TITLE
chore(servicenow): default to ven08348.service-now.com for servicenow integration

### DIFF
--- a/web-example/public/index.html
+++ b/web-example/public/index.html
@@ -379,7 +379,7 @@
         CobrowseIO.ignoredViews = ['now-requestor-chat-popover'];
 
         const params = new URLSearchParams(window.location.search);
-        const snUrl = params.get('service-now-url') ?? "https://dev305592.service-now.com";
+        const snUrl = params.get('service-now-url') ?? "https://ven08348.service-now.com/";
         const script = document.createElement('script')
         script.type = 'module'
         script.src = `${snUrl}/uxasset/externals/now-requestor-chat-popover-app/index.jsdbx?sysparm_substitute=false`

--- a/web-example/public/index.html
+++ b/web-example/public/index.html
@@ -370,9 +370,9 @@
         script.src = 'https://oc-cdn-ocprod.azureedge.net/livechatwidget/scripts/LiveChatBootstrapper.js'
         script.id = 'Microsoft_Omnichannel_LCWidget'
         const params = new URLSearchParams(window.location.search);
-        script.setAttribute('data-app-id', params.get('dynamics-app-id') ?? '25eadfd0-e1d7-44c7-bf8d-d0492f151422')
-        script.setAttribute('data-org-id', params.get('dynamics-org-id') ?? 'e90be679-05c9-f011-89f3-6045bd003e0f')
-        script.setAttribute('data-org-url', params.get('dynamics-org-url') ?? 'https://m-e90be679-05c9-f011-89f3-6045bd003e0f.us.omnichannelengagementhub.com')
+        script.setAttribute('data-app-id', params.get('dynamics-app-id') ?? '18a47619-b83f-49d8-8ea8-98ac303420f3')
+        script.setAttribute('data-org-id', params.get('dynamics-org-id') ?? '9800cc62-aa32-f111-a7e5-000d3a33780f')
+        script.setAttribute('data-org-url', params.get('dynamics-org-url') ?? 'https://m-9800cc62-aa32-f111-a7e5-000d3a33780f.us.omnichannelengagementhub.com')
         script.setAttribute('data-lcw-version', 'prod')
         document.body.appendChild(script)
       } else if (integration === 'servicenow') {

--- a/web-example/src/data/integrationLicense.js
+++ b/web-example/src/data/integrationLicense.js
@@ -9,5 +9,6 @@ export const licenses = {
   five9: '_lNWvygfLTY0kA',
   talkdesk: 'rV6E9pfNJkxm8w',
   dynamics: 'LErxNk_PrhOqgg',
-  amazonconnect: 'cM6TEJoKz1qLjA'
+  amazonconnect: 'cM6TEJoKz1qLjA',
+  servicenow: 'p6onA5C0NbJ7sg'
 }


### PR DESCRIPTION
We have 3 servicenow instances. ven08348 has been upgraded to the latest public available SN version (Zurich). As it's quite painful to set up an SN instance, we'll dedicate ven08348 to the "production" instance. This PR ensures that we can load up https://cobrowse-sdk-js-examples.cbrws.io/web-example/demo/?integration=servicenow and end up on the right SN instance by default without having to specify a license or servicenow-url param.